### PR TITLE
Explicit require active_support prior to active_support/core_ext

### DIFF
--- a/lib/taskwarrior-web.rb
+++ b/lib/taskwarrior-web.rb
@@ -2,6 +2,7 @@ $:.unshift(File.dirname(__FILE__)) unless
   $:.include?(File.dirname(__FILE__)) || $:.include?(File.expand_path(File.dirname(__FILE__)))
 
 require 'rubygems'
+require 'active_support'
 require 'active_support/core_ext'
 require 'taskwarrior-web/version'
 


### PR DESCRIPTION
Fixes error when starting.
See here: rails/rails#14664 (https://github.com/rails/rails/issues/14664)